### PR TITLE
Install dependencies for non symlink builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,15 @@ if($ENV{ROS_VERSION} MATCHES "2")
     hesai_ros_driver_node
     DESTINATION lib/${PROJECT_NAME})
 
+  install(TARGETS
+    source_lib
+    container_lib
+    ptcClient_lib
+    ptcParser_lib
+    log_lib
+    platutils_lib
+    DESTINATION lib)
+
   install(DIRECTORY
     launch
     rviz


### PR DESCRIPTION
Install Hesai's required dependencies so that we can build without --symlink-install. 