### PR TITLE
Change the default frame name to nova convention

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,7 +18,7 @@ lidar:
       pitch: 0
       yaw: 1.570796327
     ros:
-      ros_frame_id: hesai_lidar                      #Frame id of packet message and point cloud message
+      ros_frame_id: front_3d_lidar                      #Frame id of packet message and point cloud message
       ros_recv_packet_topic: /lidar_packets         #Topic used to receive lidar packets from rosbag
       ros_send_packet_topic: /lidar_packets         #Topic used to send lidar raw packets through ROS
       ros_send_point_cloud_topic: /lidar_points     #Topic used to send point cloud through ROS


### PR DESCRIPTION
default frame name is hesai_lidar in the config, which is different from the nova calibration frame name which is front_3d_lidar, this makes visualization of point cloud breaks if one want to visualize point cloud in different frame in rviz